### PR TITLE
いいね機能の処理とボタンを追加

### DIFF
--- a/app/views/microposts/_microposts.html.erb
+++ b/app/views/microposts/_microposts.html.erb
@@ -1,0 +1,32 @@
+<ul class="list-unstyled">
+  <% microposts.each do |micropost| %>
+    <li class="media mb-3">
+      <img class="mr-2 rounded" src="<%= gravatar_url(micropost.user, { size: 50 }) %>" alt="">
+      <div class="media-body">
+        <div>
+          <%= link_to micropost.user.name, user_path(micropost.user) %> <span class="text-muted">posted at <%= micropost.created_at %></span>
+        </div>
+        <div>
+          <p class="mb-0"><%= micropost.content %></p>
+        </div>
+        <div>
+          <% if current_user.favoriting?(micropost) %>
+            <%= form_with(model: current_user.favorites.find_by(micropost_id: micropost.id), local: true, method: :delete) do |f| %>
+              <%= hidden_field_tag :micropost_id, micropost.id %>
+              <%= f.submit 'いいね削除', class: 'btn btn-danger btn-sm' %>
+            <% end %>
+          <% else %>
+            <%= form_with(model: current_user.favorites.build, local: true) do |f| %>
+              <%= hidden_field_tag :micropost_id, micropost.id %>
+              <%= f.submit 'いいね', class: 'btn btn-primary btn-sm' %>
+            <% end %>
+          <% end %>
+          <% if current_user == micropost.user %>
+            <%= link_to "削除", micropost, method: :delete, data: { confirm: "本当にいいですか?" }, class: 'btn btn-danger btn-sm' %>
+          <% end %>
+        </div>
+      </div>
+    </li>
+  <% end %>
+  <%= paginate microposts %>
+</ul>


### PR DESCRIPTION
# やったこと
- 定義されているメゾットを使用して、処理を実行していく。
- いいね/いいね削除のボタンを、記事の下に配置する。
- いいねボタンの下に、記事の削除ボタンを設置する。
- 繰り返し処理で、どの投稿にも常に同じ処理が実行される仕様にする。