### PR TITLE
フォローボタンの設置と処理の追記

### DIFF
--- a/app/views/relationships/_follow_button.html.erb
+++ b/app/views/relationships/_follow_button.html.erb
@@ -1,0 +1,13 @@
+<% unless current_user == user %>
+  <% if current_user.following?(user) %>
+    <%= form_with(model: current_user.relationships.find_by(follow_id: user.id), local: true, method: :delete) do |f| %>
+      <%= hidden_field_tag :follow_id, user.id %>
+      <%= f.submit 'アンフォロー', class: 'btn btn-danger btn-block' %>
+    <% end %>
+  <% else %>
+    <%= form_with(model: current_user.relationships.build, local: true) do |f| %>
+      <%= hidden_field_tag :follow_id, user.id %>
+      <%= f.submit 'フォロー', class: 'btn btn-primary btn-block' %>
+    <% end %>
+  <% end %>
+<% end %>


### PR DESCRIPTION
# やったこと
- プロフォールの下にフォロー/アンフォローボタンを設置する。
- modelで構築した関係に従った上で、フォロー/アンフォローを決めることができる。