### PR TITLE
フォロー/フォロワー一覧ページを導入

### DIFF
--- a/app/views/layouts/_flash_messages.html.erb
+++ b/app/views/layouts/_flash_messages.html.erb
@@ -1,0 +1,4 @@
+<% flash.each do |message_type, message| %>
+  <div class="alert alert-<%= message_type %>"><%= message %></div>
+<% end %>
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html  lang="ja">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Web アルビレックス新潟</title>
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css">
+
+    <%= stylesheet_link_tag  'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.6/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/js/bootstrap.min.js"></script>
+    <script defer src="https://use.fontawesome.com/releases/v5.7.2/js/all.js"></script>
+  </head>
+
+  <body>
+    <%= render 'layouts/navbar' %>
+
+    <div class="container">
+      <%= render 'layouts/flash_messages' %>
+      <%= yield %>
+    </div>
+  </body>
+</html>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,0 +1,17 @@
+<%= form_with(model: micropost, local: true) do |f| %>
+  
+   <% if micropost.errors.any? %>
+    <div id="error_explanation">
+      <ul>
+        <% micropost.errors.full_messages.each do |micropost| %>
+          <li><%= micropost %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+  
+  <%= f.label :content, '投稿フォーム' %>
+  <%= f.text_area :content, class: 'form-control', rows: 5 %>
+
+  <%= f.submit '投稿する', class: 'btn btn-primary btn-block'  %>
+<% end %>

--- a/app/views/users/_users.html.erb
+++ b/app/views/users/_users.html.erb
@@ -1,0 +1,18 @@
+<% if users.any? %>
+  <ul class="list-unstyled">
+    <% users.each do |user| %>
+      <li class="media">
+        <img class="mr-2 rounded" src="<%= gravatar_url(user, { size: 50 }) %>" alt="">
+        <div class="media-body">
+          <div>
+            <%= user.name %>
+          </div>
+          <div>
+            <p><%= link_to 'プロフィールを見る', user_path(user) %></p>
+          </div>
+        </div>
+      </li>
+    <% end %>
+  </ul>
+  <%= paginate users %>
+<% end %>

--- a/app/views/users/followers.html.erb
+++ b/app/views/users/followers.html.erb
@@ -1,0 +1,29 @@
+<div class="row">
+  <aside class="col-sm-4">
+    <div class="card">
+      <div class="card-header">
+        <h3 class="card-title"><%= @user.name %></h3>
+      </div>
+      <div class="card-body">
+        <img class="rounded img-fluid" src="<%= gravatar_url(@user, { size: 500 }) %>" alt="">
+      </div>
+    </div>
+    <div>
+      <figure>
+        <%# app/assets/images %>
+        <%= image_tag "https://cdn.pixabay.com/photo/2013/09/16/19/36/soccer-182994_960_720.jpg", alt: "サッカーの楽しさ", id: "assets", class: "image", width: "200px" %>
+        <figcaption> サッカーの盛り上がり！</figcaption>
+      </figure>
+    </div>
+    <%= render 'relationships/follow_button', user: @user %>
+  </aside>
+  <div class="col-sm-8">
+    <ul class="nav nav-tabs nav-justified mb-3">
+      <li class="nav-item"><a href="<%= user_path(@user) %>" class="nav-link <%= 'active' if current_page?(user_path(@user)) %>">投稿一覧 <span class="badge badge-secondary"><%= @count_microposts %></span></a></li>
+      <li class="nav-item"><a href="<%= followings_user_path(@user) %>" class="nav-link <%= 'active' if current_page?(followings_user_path(@user)) %>">フォロー <span class="badge badge-secondary"><%= @count_followings %></span></a></li>
+      <li class="nav-item"><a href="<%= followers_user_path(@user) %>" class="nav-link <%= 'active' if current_page?(followers_user_path(@user)) %>">フォロワー <span class="badge badge-secondary"><%= @count_followers %></span></a></li>
+      <li class="nav-item"><a href="<%= likes_user_path(@user) %>" class="nav-link <%= 'active' if current_page?(likes_user_path(@user)) %>">いいね <span class="badge badge-secondary"><%= @count_likes %></span></a></li>
+    </ul>
+    <%= render 'users', users: @followers %>
+  </div>
+</div>

--- a/app/views/users/followings.html.erb
+++ b/app/views/users/followings.html.erb
@@ -1,0 +1,29 @@
+<div class="row">
+  <aside class="col-sm-4">
+    <div class="card">
+      <div class="card-header">
+        <h3 class="card-title"><%= @user.name %></h3>
+      </div>
+      <div class="card-body">
+        <img class="rounded img-fluid" src="<%= gravatar_url(@user, { size: 500 }) %>" alt="">
+      </div>
+    </div>
+    <div>
+      <figure>
+        <%# app/assets/images %>
+        <%= image_tag "https://cdn.pixabay.com/photo/2013/09/16/19/36/soccer-182994_960_720.jpg", alt: "サッカーの楽しさ", id: "assets", class: "image", width: "200px" %>
+        <figcaption> サッカーの盛り上がり！</figcaption>
+      </figure>
+    </div>
+    <%= render 'relationships/follow_button', user: @user %>
+  </aside>
+  <div class="col-sm-8">
+    <ul class="nav nav-tabs nav-justified mb-3">
+      <li class="nav-item"><a href="<%= user_path(@user) %>" class="nav-link <%= 'active' if current_page?(user_path(@user)) %>">投稿一覧 <span class="badge badge-secondary"><%= @count_microposts %></span></a></li>
+      <li class="nav-item"><a href="<%= followings_user_path(@user) %>" class="nav-link <%= 'active' if current_page?(followings_user_path(@user)) %>">フォロー <span class="badge badge-secondary"><%= @count_followings %></span></a></li>
+      <li class="nav-item"><a href="<%= followers_user_path(@user) %>" class="nav-link <%= 'active' if current_page?(followers_user_path(@user)) %>">フォロワー <span class="badge badge-secondary"><%= @count_followers %></span></a></li>
+      <li class="nav-item"><a href="<%= likes_user_path(@user) %>" class="nav-link <%= 'active' if current_page?(likes_user_path(@user)) %>">いいね  <span class="badge badge-secondary"><%= @count_likes %></span></a></li>
+    </ul>
+    <%= render 'users', users: @followings %>
+  </div>
+</div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,0 +1,1 @@
+<%= render 'users', users: @users %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,1 +1,0 @@
-<%= render 'users', users: @users %>


### PR DESCRIPTION
# やったこと
- タブ機能のリンクで、フォロー/フォロワー一覧ページへ移動することができる。
- ユーザーが一覧として見えるように、縦に並ぶ仕様にした。
- それぞれのユーザーの数もわかるように、常に増減していく処理を設定した。