### PR TITLE
投稿記事の一覧機能の導入

### DIFF
--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,0 +1,1 @@
+<%= render 'users', users: @users %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,29 @@
+<div class="row">
+  <aside class="col-sm-4">
+    <div class="card">
+      <div class="card-header">
+        <h3 class="card-title"><%= @user.name %></h3>
+      </div>
+      <div class="card-body">
+        <img class="rounded img-fluid" src="<%= gravatar_url(@user, { size: 500 }) %>" alt="">
+      </div>
+    </div>
+    <%= render 'relationships/follow_button', user: @user %>
+    <div>
+      <figure>
+        <%# app/assets/images %>
+        <%= image_tag "https://cdn.pixabay.com/photo/2013/09/16/19/36/soccer-182994_960_720.jpg", alt: "サッカーの楽しさ", id: "assets", class: "image", width: "200px" %>
+        <figcaption> サッカーの盛り上がり！</figcaption>
+      </figure>
+    </div>
+  </aside>
+  <div class="col-sm-8">
+    <ul class="nav nav-tabs nav-justified mb-3">
+      <li class="nav-item"><a href="<%= user_path(@user) %>" class="nav-link <%= 'active' if current_page?(user_path(@user)) %>">投稿一覧 <span class="badge badge-secondary"><%= @count_microposts %></span></a></li>
+      <li class="nav-item"><a href="<%= followings_user_path(@user) %>" class="nav-link <%= 'active' if current_page?(followings_user_path(@user)) %>">フォロー <span class="badge badge-secondary"><%= @count_followings %></span></a></li>
+      <li class="nav-item"><a href="<%= followers_user_path(@user) %>" class="nav-link <%= 'active' if current_page?(followers_user_path(@user)) %>">フォロワー <span class="badge badge-secondary"><%= @count_followers %></span></a></li>
+      <li class="nav-item"><a href="<%= likes_user_path(@user) %>" class="nav-link <%= 'active' if current_page?(likes_user_path(@user)) %>">いいね  <span class="badge badge-secondary"><%= @count_likes %></span></a></li>
+    </ul>
+    <%= render 'microposts/microposts', microposts: @microposts %>
+  </div>
+</div>


### PR DESCRIPTION
# やったこと
- タブ機能のリンクで、いいね一覧ページと、フォロー/フォロワー一覧ページへ移動することができる。
- 投稿が一覧として見えるように、縦に並ぶ仕様にした。
- それぞれの投稿記事の数もわかるように、常に増減していく処理を設定した。